### PR TITLE
Add parameter for Audio

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -89,6 +89,10 @@ Audio.State = {
             audio = this;
         var item = cc.loader.getItem(src);
 
+        if (!item) {
+            item = cc.loader.getItem(src + '?useDom=1');
+        }
+
         // If the resource does not exist
         if (!item) {
             return cc.loader.load(src, function (error) {


### PR DESCRIPTION
问题表现：

在编辑器内勾选 domAudio 加载方式后，在代码内使用如：
```javascript
cc.audioEngine.playMusic('res/raw-assets/resources/audio/music_logo.mp3')
```
代码播放，会导致重新使用 webAudio 的方式加载一遍音频，并重新缓存。

原因是因为现在使用带参数的链接作为缓存的 id，所以 domAudio 的缓存索引 id 应该是 res/raw-assets/resources/audio/music_logo.mp3?useDom=1 。这时候使用不带参数的 url 就找不到正确的索引了，所以重新加载了一遍。

这里在找不到缓存 item 的时候，加上参数重新获取一遍缓存。避免找不到缓存的问题。

https://github.com/cocos-creator/engine/pull/1410