### PR TITLE
Resolve the clear error of the mask

### DIFF
--- a/cocos2d/core/CCScene.js
+++ b/cocos2d/core/CCScene.js
@@ -97,10 +97,6 @@ cc.Scene = cc.Class({
             }
             else {
                 this._onBatchCreated();
-                // Temporary solution: Resolve the error of the mask on the native-renderer
-                this._trs[1] = 0;
-                this._trs[2] = 0;
-                this._trs[3] = 0;
             }
             this._inited = true;
         }

--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -399,7 +399,9 @@ let Mask = cc.Class({
             this._clearGraphics.node = new Node();
             this._clearGraphics._activateMaterial();
             this._clearGraphics.lineWidth = 0;
-            this._clearGraphics.rect(0, 0, cc.visibleRect.width, cc.visibleRect.height);
+            // Resolve the clear error of the mask
+            let scene = cc.director.getScene();
+            this._clearGraphics.rect(scene.x, scene.y, cc.visibleRect.width, cc.visibleRect.height);
             this._clearGraphics.fill();
             if (CC_JSB && CC_NATIVERENDERER) {
                 this._renderHandle.setNativeClearHandle(this._clearGraphics._renderHandle);


### PR DESCRIPTION
问题说明：scene的位置偏移会造成原本起始点为（0，0）点的clearGraphics与场景节点更新对齐位置之后有对应的位置偏移，在Web端跟NativeRenderer都会有这样的问题，但是非Inverted模式在Web端测试不出问题，在Web端测试IMAGE—STENCIL的Inverted模式能够暴露问题。

解决：除了直接设置clearGraphics的起始位置偏移之外也可以把clearGraphics的所属节点的位置设置为scene的position并重新计算下世界矩阵，然后由model的世界矩阵来完成顶点位置的偏移，不过NativeRenderer端还要传递并保存该节点引用，所以还是用简单的方式处理吧。